### PR TITLE
Add support for AWS_REGION env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ possible, but it is not implemented here.
 
 1. Download the [s3simple](s3simple) script somewhere.
 2. Set `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` and optionally
-`AWS_SESSION_TOKEN` environment variables.
+   `AWS_SESSION_TOKEN` and `AWS_REGION` environment variables.
 3. Run `s3simple` with a method, an `s3://` url and, optionally, a local
-filename.
+   filename.
 
 For example:
 
@@ -32,6 +32,8 @@ For example:
     export AWS_SECRET_ACCESS_KEY=zzzz
     # optionally provide a temporary session token
     export AWS_SESSION_TOKEN=wwww...
+    # optionally specify the AWS region to avoid 307 redirects
+    export AWS_REGION=eu-west-3
 
     # get a file
     ./s3simple get s3://mybucket/myfile.txt myfile.txt

--- a/s3simple
+++ b/s3simple
@@ -15,7 +15,7 @@ s3simple() {
   fi
   local path="${url:5}"
 
-  if [ -z "${AWS_ACCESS_KEY_ID-}"  ]; then
+  if [ -z "${AWS_ACCESS_KEY_ID-}" ]; then
     echo "Need AWS_ACCESS_KEY_ID to be set"
     return 1
   fi
@@ -49,6 +49,7 @@ s3simple() {
   *)
     echo "Unsupported command"
     return 1
+    ;;
   esac
 
   local aws_headers=""
@@ -71,7 +72,14 @@ s3simple() {
   local bucket="${path%/*}"
   local key="${path#*/}"
 
-  curl "${args[@]}" -s -f -H "Date: ${date}" -H "Authorization: ${authorization}" "https://${bucket}.s3.amazonaws.com/${key}"
+  local url
+  if [ z "${AWS_REGION-}" ]; then
+    url="s3-${AWS_REGION}.amazonaws.com"
+  else
+    url="s3.amazonaws.com"
+  fi
+
+  curl "${args[@]}" -s -f -H "Date: ${date}" -H "Authorization: ${authorization}" "https://${bucket}.${url}/${key}"
 }
 
 s3simple "$@"


### PR DESCRIPTION
I was facing some HTTP code 307 redirects when using the scripts, so I added the possibility to use a `AWS_REGION` environment variable.